### PR TITLE
chore: bump version to v2.0.0-alpha.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # magda-auth-okta
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square)
+![Version: 2.0.0-alpha.0](https://img.shields.io/badge/Version-2.0.0--alpha.0-informational?style=flat-square)
 
 A Magda Authentication Plugin for Okta.
 

--- a/deploy/magda-auth-okta/Chart.yaml
+++ b/deploy/magda-auth-okta/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: magda-auth-okta
 description: A Magda Authentication Plugin for Okta.
-version: "1.1.1"
+version: "2.0.0-alpha.0"
 kubeVersion: ">= 1.14.0-0"
 home: "https://github.com/magda-io/magda-auth-okta"
 sources: [ "https://github.com/magda-io/magda-auth-okta" ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magda-auth-okta",
-  "version": "1.1.1",
+  "version": "2.0.0-alpha.0",
   "description": "A Generic Magda Okta Auth Plugin",
   "repository": "https://github.com/magda-io/magda-auth-okta.git",
   "author": "Jacky Jiang",


### PR DESCRIPTION
Bump `main` to `v2.0.0-alpha.0` following the pre-release of the v2 line.

This carries the version bump (package.json / Chart.yaml / README badge) produced by the `set-version` workflow on the release branch back to `main`, so `main` no longer trails on `1.1.1`. No functional changes.